### PR TITLE
Fix compilation error 'invalid use of incomplete type ‘class STRING’'

### DIFF
--- a/include/ctesseract/ctess_string.h
+++ b/include/ctesseract/ctess_string.h
@@ -2,6 +2,7 @@
 #define __CTESS_STRING_H
 
 #include <tesseract/baseapi.h>
+#include <tesseract/strngs.h>
 
 typedef struct {
     STRING *tess_string;


### PR DESCRIPTION
Hi there,
I don't know if the issue was caused by a different version of gcc or tesseract itself, but I had a compilation error, this commit fixes it.

Thx
